### PR TITLE
Various memory/efficiency improvements for control/PCM ROM loader

### DIFF
--- a/emusc/src/emulator.cc
+++ b/emusc/src/emulator.cc
@@ -768,7 +768,7 @@ void Emulator::select_prev_instrument()
   uint8_t index = _emuscSynth->get_part_instrument(_selectedPart, bank);
 
   if (_emuscSynth->get_part_mode(_selectedPart) == 0) {     // Instrument
-    const std::vector<uint16_t> &var = _emuscControlRom->variation(bank);
+    const std::array<uint16_t, 128> &var = _emuscControlRom->variation(bank);
     for (int i = index - 1; i >= 0; i--) {
       if (var[i] != 0xffff) {
 	set_instrument(i, bank, true);
@@ -797,7 +797,7 @@ void Emulator::select_next_instrument()
   uint8_t index = _emuscSynth->get_part_instrument(_selectedPart, bank);
 
   if (_emuscSynth->get_part_mode(_selectedPart) == 0) {     // Instrument
-    const std::vector<uint16_t> &var = _emuscControlRom->variation(bank);
+    const std::array<uint16_t, 128> &var = _emuscControlRom->variation(bank);
     for (int i = index + 1; i < var.size(); i++) {
       if (var[i] != 0xffff) {
 	set_instrument(i, bank, true);

--- a/libemusc/src/control_rom.cc
+++ b/libemusc/src/control_rom.cc
@@ -33,6 +33,20 @@
 
 namespace EmuSC {
 
+const std::vector<int> ControlRom::_drumSetBankSC55 =
+  { 0, 8, 16, 24, 25, 32, 40, 48, 56, 127 };
+const std::vector<int> ControlRom::_drumSetBankSC88 =
+  { 0, 1, 8, 16, 24, 25, 26, 32, 40, 48, 49, 50, 56, 57};
+const std::vector<int> ControlRom::_drumSetBankSC88Pro =
+  { 0, 1, 2, 8, 9, 10, 11, 16, 24, 25, 26, 27, 28, 29, 30, 31, 32, 40, 48,
+    49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62 };
+
+const std::vector<uint32_t> ControlRom::_banksSC55 =
+  { 0x10000, 0x1BD00, 0x1DEC0, 0x20000, 0x2BD00, 0x2DEC0, 0x30000, 0x38080 };
+
+// Only a placeholder, SC-88 layout is currently unkown
+const std::vector<uint32_t> ControlRom::_banksSC88 =
+  { 0x10000, 0x1BD00, 0x1DEC0, 0x20000, 0x2BD00, 0x2DEC0, 0x30000, 0x38080 };
 
 ControlRom::ControlRom(std::string romPath)
   : _romPath(romPath)

--- a/libemusc/src/control_rom.cc
+++ b/libemusc/src/control_rom.cc
@@ -344,18 +344,15 @@ int ControlRom::_read_variations(std::ifstream &romFile)
   const std::vector<uint32_t> &banks = _banks();
 
   // Variations are in bank 6, a table of 128 x 128 2 byte values
-  for (int32_t x = banks[6]; x < (banks[7] - 128); x += 256) {
-
-    char data[2];
-    romFile.seekg(x);
-    std::vector<uint16_t> v;
+  for (int x = 0; x < 128; x++) {
+    const size_t offset = banks[6] + x * 128 * sizeof(uint16_t);
+    romFile.seekg(offset);
 
     for (int y = 0; y < 128; y++) {
+      char data[2];
       romFile.read(data, 2);
-      v.push_back(_native_endian_uint16((uint8_t *) &data[0]));
+      _variations[x][y] = _native_endian_uint16(reinterpret_cast<uint8_t*>(data));
     }
-
-    _variations.push_back(v);
   }
 
   if (0) {

--- a/libemusc/src/control_rom.cc
+++ b/libemusc/src/control_rom.cc
@@ -486,20 +486,11 @@ int ControlRom::_read_lookup_tables(std::ifstream &romFile)
   // Lookup tables (LUTs) are located after the 8 memory banks, at the exact
   // same location for all SC-55 control ROMs
   romFile.seekg(0x03d1e8);
-  for (int i = 0; i < 12; i ++) {
-    std::vector<uint8_t> lut(128);
-    romFile.read(reinterpret_cast<char*> (&lut[0]), 128);
-    _lookupTables.push_back(lut);
-  }
+  romFile.read(reinterpret_cast<char*> (&_lookupTables[0]), 128 * 12);
 
   //  romFile.seekg(0x03de78);
   romFile.seekg(0x03dd82);
-  for (int i = 0; i < 7; i ++) {
-    std::vector<uint8_t> lut(128);
-    romFile.read(reinterpret_cast<char*> (&lut[0]), 128);
-
-    _lookupTables.push_back(lut);
-  }
+  romFile.read(reinterpret_cast<char*> (&_lookupTables[12]), 128 * 7);
 
   if (0) {
     std::cout << "  -> LUTs: (" << _lookupTables.size() << ")" << std::endl;

--- a/libemusc/src/control_rom.cc
+++ b/libemusc/src/control_rom.cc
@@ -237,6 +237,11 @@ int ControlRom::_read_instruments(std::ifstream &romFile)
 
     // First 12 bytes are the instrument name
     romFile.read(data, 12);
+
+    // Skip empty slots in the ROM file that have no instrument name
+    if (data[0] == '\0')
+      continue;
+
     i.name.assign(data , 12);
     i.name.erase(i.name.find_last_not_of(' ') + 1);
 
@@ -291,17 +296,14 @@ int ControlRom::_read_instruments(std::ifstream &romFile)
       i.partials[p].TVALenP5    = data[78];
     }
 
-    // Skip empty slots in the ROM file that has no instrument name
-    if (i.name[0]) {
-      _instruments.push_back(i);
+    _instruments.push_back(i);
 
-      if (0)
-	std::cout << "  -> Instrument " << _instruments.size() << ": " << i.name
-		  << " partial0=" << (int) i.partials[0].partialIndex
-		  << " partial1=" << (int) i.partials[1].partialIndex
-		  << std::endl;
+    if (0)
+      std::cout << "  -> Instrument " << _instruments.size() << ": " << i.name
+          << " partial0=" << (int) i.partials[0].partialIndex
+          << " partial1=" << (int) i.partials[1].partialIndex
+          << std::endl;
     }
-  }
 
   return 0;
 }

--- a/libemusc/src/control_rom.h
+++ b/libemusc/src/control_rom.h
@@ -131,7 +131,8 @@ public:
     std::string name;     // 12 chars
   };
 
-  std::vector<std::vector<uint8_t>> _lookupTables;
+  // TODO: define constants for lookup table dimensions
+  std::array<std::array<uint8_t, 128>, 19> _lookupTables;
   int _read_lookup_tables(std::ifstream &romFile);
   uint8_t lookup_table(uint8_t table, uint8_t index);
   float lookup_table(uint8_t table, float index, int interpolate = 1);

--- a/libemusc/src/control_rom.h
+++ b/libemusc/src/control_rom.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 
+#include <array>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -155,7 +156,7 @@ public:
   inline struct Partial& partial(int p) { return _partials[p]; }
   inline struct Sample& sample(int s) { return _samples[s]; }
   inline struct DrumSet& drumSet(int ds) { return _drumSets[ds]; }
-  const std::vector<uint16_t>& variation(int v) { return _variations[v]; }
+  inline const std::array<uint16_t, 128>& variation(int v) const { return _variations[v]; }
 
   inline int numSampleSets(void) { return _samples.size(); }
   inline int numInstruments(void) { return _instruments.size(); }
@@ -215,7 +216,8 @@ private:
   std::vector<Partial> _partials;
   std::vector<Sample> _samples;
   std::vector<DrumSet> _drumSets;
-  std::vector<std::vector<uint16_t>> _variations;
+  // TODO: define constants for variation table dimensions
+  std::array<std::array<uint16_t, 128>, 128> _variations;
 
   ControlRom();
 

--- a/libemusc/src/control_rom.h
+++ b/libemusc/src/control_rom.h
@@ -181,20 +181,14 @@ private:
   const uint8_t _maxPolyphonySC55mkII = 28;
   const uint8_t _maxPolyphonySC88     = 64;
 
-  const std::vector<int> _drumSetBankSC55 =
-    { 0, 8, 16, 24, 25, 32, 40, 48, 56, 127 };
-  const std::vector<int> _drumSetBankSC88 =
-    { 0, 1, 8, 16, 24, 25, 26, 32, 40, 48, 49, 50, 56, 57};
-  const std::vector<int> _drumSetBankSC88Pro =
-    { 0, 1, 2, 8, 9, 10, 11, 16, 24, 25, 26, 27, 28, 29, 30, 31, 32, 40, 48,
-      49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62 };
+  static const std::vector<int> _drumSetBankSC55;
+  static const std::vector<int> _drumSetBankSC88;
+  static const std::vector<int> _drumSetBankSC88Pro;
 
-  const std::vector<uint32_t> _banksSC55 =
-    { 0x10000, 0x1BD00, 0x1DEC0, 0x20000, 0x2BD00, 0x2DEC0, 0x30000, 0x38080 };
+  static const std::vector<uint32_t> _banksSC55;
 
   // Only a placeholder, SC-88 layout is currently unkown
-  const std::vector<uint32_t> _banksSC88 =
-    { 0x10000, 0x1BD00, 0x1DEC0, 0x20000, 0x2BD00, 0x2DEC0, 0x30000, 0x38080 };
+  static const std::vector<uint32_t> _banksSC88;
 
   int _identify_model(std::ifstream &romFile);
   const std::vector<uint32_t> &_banks(void);

--- a/libemusc/src/control_rom.h
+++ b/libemusc/src/control_rom.h
@@ -177,9 +177,9 @@ private:
   };
   enum SynthModel _synthModel;
 
-  const uint8_t _maxPolyphonySC55     = 24;
-  const uint8_t _maxPolyphonySC55mkII = 28;
-  const uint8_t _maxPolyphonySC88     = 64;
+  static constexpr uint8_t _maxPolyphonySC55     = 24;
+  static constexpr uint8_t _maxPolyphonySC55mkII = 28;
+  static constexpr uint8_t _maxPolyphonySC88     = 64;
 
   static const std::vector<int> _drumSetBankSC55;
   static const std::vector<int> _drumSetBankSC88;

--- a/libemusc/src/pcm_rom.cc
+++ b/libemusc/src/pcm_rom.cc
@@ -72,6 +72,8 @@ PcmRom::PcmRom(std::vector<std::string> romPath, ControlRom &ctrlRom)
   }
 
   // Read through the entire memory and extract sample sets
+  _sampleSets.reserve(ctrlRom.numSampleSets());
+
   for (int i = 0; i < ctrlRom.numSampleSets(); i ++)
     _read_samples(romData, ctrlRom.sample(i));
 
@@ -142,6 +144,7 @@ int PcmRom::_read_samples(std::vector<char> romData, struct ControlRom::Sample &
   uint32_t romAddress = _find_samples_rom_address(ctrlSample.address);
 
   struct Samples s;
+  s.samplesF.reserve(ctrlSample.sampleLen);
 
   // Read PCM samples from ROM
   for (int i = 0; i < ctrlSample.sampleLen; i++) {


### PR DESCRIPTION
`std::vector` is a container which can trigger requests for more memory from the operating system every time its heap-allocated storage is filled. When performing thousands of `push_back()` operations, this can result in many expensive calls to `malloc()`/`free()` (and copy/move operations) behind the scenes, as larger chunks of memory are requested, data is moved from the old location to the new location, and the old location is freed.

On modern machines with operating systems that provide sophisticated memory allocators, memory fragmentation isn't a problem and we can get away with this.

However, on embedded/baremetal systems which aren't able to avoid memory fragmentation, this can cause problems, so we should try to avoid unnecessary reallocations by reserving the space up-front whenever it is known.

This PR reduces overall memory allocations inside `libemusc.so` from ~13000 to ~3000 as shown by the following heaptrack trace:
![image](https://user-images.githubusercontent.com/5890747/205401893-841d7be7-33ec-4b50-a949-df08a6fd16a6.png)

There are probably more places where this can be improved further, but this should take care of the low-hanging fruit.

Cheers!