### PR TITLE
Fix CMake builds on Fedora

### DIFF
--- a/emusc/src/CMakeLists.txt
+++ b/emusc/src/CMakeLists.txt
@@ -68,4 +68,5 @@ target_link_libraries(emusc-client Qt5::Gui)
 target_link_libraries (emusc-client ${EXTERNAL_LIBRARIES})
 
 target_compile_features(emusc-client PUBLIC cxx_std_11)
+target_include_directories(emusc-client PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 set_target_properties(emusc-client PROPERTIES CXX_EXTENSIONS OFF)

--- a/libemusc/src/CMakeLists.txt
+++ b/libemusc/src/CMakeLists.txt
@@ -32,4 +32,5 @@ add_library(emusc
 
 
 target_compile_features(emusc PUBLIC cxx_std_11)
+target_include_directories(emusc PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 set_target_properties(emusc PROPERTIES CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Previously it was causing builds to fail due to being unable to find the generated `config.h` header.