### PR TITLE
Invert conditional checks for Midi setting to fix bug of listing devices

### DIFF
--- a/emusc/src/preferences_dialog.cc
+++ b/emusc/src/preferences_dialog.cc
@@ -862,7 +862,7 @@ void MidiSettings::_systemCB_changed(int index)
 {
   _deviceCB->clear();
 
-  if (!_systemCB->currentText().compare("Core", Qt::CaseInsensitive)) {
+  if (_systemCB->currentText().compare("Core", Qt::CaseInsensitive)) {
     // List all available MIDI devices - or show a warning if none    
 #ifdef __CORE_MIDI__
     QStringList devices = MidiInputCore::get_available_devices();
@@ -871,7 +871,7 @@ void MidiSettings::_systemCB_changed(int index)
       _deviceCB->addItem(d);
 #endif
 
-  } else if (!_systemCB->currentText().compare("alsa", Qt::CaseInsensitive)) {
+  } else if (_systemCB->currentText().compare("alsa", Qt::CaseInsensitive)) {
 #ifdef __ALSA_MIDI__
     QStringList devices = MidiInputAlsa::get_available_devices();
 
@@ -879,7 +879,7 @@ void MidiSettings::_systemCB_changed(int index)
       _deviceCB->addItem(d);
 #endif
 
-  } else if (!_systemCB->currentText().compare("win32", Qt::CaseInsensitive)) {
+  } else if (_systemCB->currentText().compare("win32", Qt::CaseInsensitive)) {
 #ifdef __WIN32_MIDI__
     QStringList devices = MidiInputWin32::get_available_devices();
 


### PR DESCRIPTION

I noticed this on my MacOS system where the Core Midi should work, but it did not list devices.

After removing the not operator, devices were listed in the UI and selectable.

I believe this is how the code should be, although I have not tested the other environments.