### PR TITLE
Explicitly set CMAKE_RUNTIME_OUTPUT_DIRECTORY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(
   LANGUAGES CXX)
   
 option(emusc_WITH_EMUSC_CLIENT "Build GUI client application" TRUE)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(libemusc)
 


### PR DESCRIPTION
Necessary for IDEs like CLion, which might by default build into a directory like "cmake-build-debug". 

See https://stackoverflow.com/a/38166227/264970

Reviewer: Please try it locally to verify everything still works for you.