### PR TITLE
DPCM fixes

### DIFF
--- a/libemusc/src/partial.h
+++ b/libemusc/src/partial.h
@@ -59,7 +59,7 @@ private:
 
   unsigned int _lastPos;  // Last read sample position
   float _index;           // Sample position in number of samples from start
-  bool _direction;        // Sample read direction: 0 = backward & 1 = foreward
+  int _direction;         // Sample looping direction: -1 = backward, 1 = forward
 
   float _expFactor;       // log(2) / 12000
 

--- a/libemusc/src/pcm_rom.cc
+++ b/libemusc/src/pcm_rom.cc
@@ -139,6 +139,7 @@ int PcmRom::_read_samples(std::vector<char> &romData, struct ControlRom::Sample 
 {
   uint32_t romAddress = _find_samples_rom_address(ctrlSample.address);
 
+  float sample = 0;
   struct Samples s;
   s.samplesF.reserve(ctrlSample.sampleLen + 1);
 
@@ -152,8 +153,10 @@ int PcmRom::_read_samples(std::vector<char> &romData, struct ControlRom::Sample 
 
     // Convert to float
     float ffinal = (float) final / (1 << 31);
+    // Accumulate (interpret as DPCM)
+    sample += ffinal;
 
-    s.samplesF.push_back(ffinal);
+    s.samplesF.push_back(sample);
   }
 
   _sampleSets.push_back(s);

--- a/libemusc/src/pcm_rom.cc
+++ b/libemusc/src/pcm_rom.cc
@@ -140,10 +140,10 @@ int PcmRom::_read_samples(std::vector<char> &romData, struct ControlRom::Sample 
   uint32_t romAddress = _find_samples_rom_address(ctrlSample.address);
 
   struct Samples s;
-  s.samplesF.reserve(ctrlSample.sampleLen);
+  s.samplesF.reserve(ctrlSample.sampleLen + 1);
 
   // Read PCM samples from ROM
-  for (int i = 0; i < ctrlSample.sampleLen; i++) {
+  for (int i = 0; i <= ctrlSample.sampleLen; i++) {
     uint32_t sAddress = romAddress + i;
     int8_t data = romData[sAddress];
     uint8_t sByte = romData[((sAddress & 0xFFFFF) >> 5)|(sAddress & 0xF00000)];


### PR DESCRIPTION
- Add one extra missing frame in PCM ROM read 
  - Fixes off-by-one error that resulted in dropping the last sample value.
- Interpret wave ROM samples as DPCM data during initial read 
  - This simplifies matters when reading through the sample data later.
- Rewrite sample traversal logic to reduce popping in ping-pong mode