### PR TITLE
Fixes for macOS CoreMIDI

### DIFF
--- a/emusc/src/midi_input_core.h
+++ b/emusc/src/midi_input_core.h
@@ -47,6 +47,7 @@ private:
   uint16_t _sysExDataLength;
 
   void _midi_callback(const MIDIPacketList* packetList, void *srcConnRefCon);
+  static QString _get_device_name(MIDIEndpointRef source);
 
 public:
   MidiInputCore();


### PR DESCRIPTION
This addresses two big problems on macOS: 
- MIDI devices show up as empty string
- Stuck notes