### PR TITLE
Fix crash bugs

### DIFF
--- a/libemusc/src/part.cc
+++ b/libemusc/src/part.cc
@@ -553,9 +553,11 @@ int Part::set_program(uint8_t index, int8_t bank, bool ignRxFlags)
     if (bank < 63 && index < 120) {
       while (instrument == 0xffff)
 	instrument = _ctrlRom.variation(--bank)[index];
-
-      _settings->set_param(PatchParam::ToneNumber, bank, _id);
     }
+    if (instrument == 0xffff) // FIXME: Just a workaround
+      bank = 0;
+
+    _settings->set_param(PatchParam::ToneNumber, bank, _id);
 
   // If part is used for drums, select correct drum set
   } else {

--- a/libemusc/src/part.cc
+++ b/libemusc/src/part.cc
@@ -457,11 +457,11 @@ int Part::control_change(uint8_t msgId, uint8_t value)
 
   } else if (msgId == 126) {                           // Mono (-> Mode 4)
     stop_all_notes();
-    _settings->set_param(PatchParam::PolyMode, 0, _id);
+    _settings->set_param(PatchParam::PolyMode, (uint8_t) 0, (int8_t) _id);
 
   } else if (msgId == 127) {                           // Poly (-> Mode 3)
     stop_all_notes();
-    _settings->set_param(PatchParam::PolyMode, 1, _id);
+    _settings->set_param(PatchParam::PolyMode, (uint8_t) 1, (int8_t) _id);
   }
 
   // Update CC1 and CC2 based on configured controller inputs


### PR DESCRIPTION
This PR fixes the following crash bugs:

### c9616c842f56b510cef1193fbbb19d38fb12e72a: Fix a crash bug when receiving CC#126 Mono message on >2 ch

When `_settings->set_param(PatchParam::PolyMode, 0, _id);` is compiled,
`void set_param(enum PatchParam pp, uint8_t value, int8_t part = -1)`  
is not called and
`void set_param(enum PatchParam pp, uint8_t *data, uint8_t size = 1, int8_t part = -1)`  
is mistakenly called because the literal `0` fits both pointer and integer types.

The method of casting arguments to resolve function overloading is different here and there in `Part::control_change()`. So, it might be better to unify.

A SMF to reproduce is below:
* [MonoMessageCausesCrash.zip](https://github.com/skjelten/emusc/files/15443359/MonoMessageCausesCrash.zip)

### be4b5e5b6032408ca317b673ddfa1bba60951eb2: Workaround a crash bug when specifying missing instrument that is not in range of CTF

When a non-existent tone is specified, if the condition `if (bank < 63 && index < 120)` is not met, it is not subject to CTF. In this case, the app crashes, perhaps because the tone is not finally selected. This fix is just a W/A because the cause could not be determined.

It might be necessary to introduce a "NO INSTRUMENT"-like state for a radical solution.

SMFs to reproduce are below:
* [NoInstrumentCausesCrash.zip](https://github.com/skjelten/emusc/files/15443362/NoInstrumentCausesCrash.zip)
