### PR TITLE
Fix wrong pitch bug when receiving CC#121 (Reset All Controllers)

### DIFF
--- a/libemusc/src/biquad_filter.h
+++ b/libemusc/src/biquad_filter.h
@@ -30,8 +30,6 @@ public:
   BiquadFilter();
   virtual ~BiquadFilter() = 0;
 
-  virtual void calculate_coefficients(float frequency, float q) = 0;
-
   float apply(float input);
 
 protected:

--- a/libemusc/src/control_rom.cc
+++ b/libemusc/src/control_rom.cc
@@ -281,8 +281,7 @@ int ControlRom::_read_instruments(std::ifstream &romFile)
       i.partials[p].pitchDurP5  = data[23];
       i.partials[p].TVFBaseFlt  = data[33];
       i.partials[p].TVFResonance= data[34];
-      i.partials[p].TVFType     = data[35];
-      i.partials[p].TVFCFKeyFlw = data[37];
+      i.partials[p].LowVelClear = data[35];
       i.partials[p].TVFLFO1Depth= data[38];
       i.partials[p].TVFLFO2Depth= data[39];
       i.partials[p].TVFLvlInit  = data[40];

--- a/libemusc/src/control_rom.h
+++ b/libemusc/src/control_rom.h
@@ -93,9 +93,7 @@ public:
 
     int8_t TVFBaseFlt;
     int8_t TVFResonance;
-    int8_t TVFType;       // TVF Type [ low pass | high pass | disabled ]
-
-    uint8_t TVFCFKeyFlw;  // TVF Cutoff Frequency Key Follow
+    int8_t LowVelClear;
 
     uint8_t TVFLFO1Depth;
     uint8_t TVFLFO2Depth;

--- a/libemusc/src/part.cc
+++ b/libemusc/src/part.cc
@@ -410,7 +410,7 @@ int Part::control_change(uint8_t msgId, uint8_t value)
     delete_all_notes();
 
   } else if (msgId == 121) {                           // Reset All Controllers
-    pitch_bend_change(0x00, 0x20, true);
+    pitch_bend_change(0x00, 0x40, true);
     _settings->set_param(PatchParam::PolyKeyPressure, 0, (int8_t) _id);
     _settings->set_param(PatchParam::ChannelPressure, 0, (int8_t) _id);
     _settings->set_param(PatchParam::Modulation, 0, (int8_t) _id);

--- a/libemusc/src/tvf.h
+++ b/libemusc/src/tvf.h
@@ -21,9 +21,9 @@
 #define __TVF_H__
 
 
-#include "biquad_filter.h"
 #include "control_rom.h"
 #include "envelope.h"
+#include "lowpass_filter2.h"
 #include "settings.h"
 #include "wave_generator.h"
 
@@ -67,15 +67,12 @@ private:
   uint8_t _key;
 
   Envelope *_envelope;
-
-  BiquadFilter *_bqFilter;
+  LowPassFilter2 *_lpFilter;
 
   ControlRom::InstPartial &_instPartial;
 
   Settings *_settings;
   int8_t _partId;
-
-  float _logSemitoneRatio;
 
   TVF();
 


### PR DESCRIPTION
There are some MIDI files that cause wrong pitch when played on EmuSC, and it seems that this bug is the cause. If CC#121 is used in MIDI files, the pitch bend will be “reset” to -4096.